### PR TITLE
improve error messages

### DIFF
--- a/library.js
+++ b/library.js
@@ -56,7 +56,7 @@ const KeepAliveWorkflow = async (githubToken, committerUsername, committerEmail,
         resolve('Nothing to do...');
       }
     } catch (e) {
-      reject(e.toString());
+      reject(e);
     }
   });
 };

--- a/util.js
+++ b/util.js
@@ -29,7 +29,7 @@ const execute = (cmd, args = [], options = {}) => new Promise((resolve, reject) 
     }
     return resolve({code, outputData});
   });
-  app.on('error', () => reject({code: 1, outputData}));
+  app.on('error', (error) => reject({code: 1, outputData, error}));
 });
 
 module.exports = {

--- a/util.js
+++ b/util.js
@@ -25,11 +25,11 @@ const execute = (cmd, args = [], options = {}) => new Promise((resolve, reject) 
 
   app.on('close', (code) => {
     if (code !== 0) {
-      return reject({code, outputData});
+      return reject({command: cmd+" "+args.join(" "), code, outputData, error: "non-zero exit code"});
     }
     return resolve({code, outputData});
   });
-  app.on('error', (error) => reject({code: 1, outputData, error}));
+  app.on('error', (error) => reject({command: cmd+" "+args.join(" "), code: 1, outputData, error}));
 });
 
 module.exports = {

--- a/util.js
+++ b/util.js
@@ -1,4 +1,5 @@
 const {spawn} = require('child_process');
+const core = require('@actions/core');
 
 /**
  * @description Executes a command and returns its result as promise
@@ -20,6 +21,13 @@ const execute = (cmd, args = [], options = {}) => new Promise((resolve, reject) 
     // Only needed for pipes
     app.stdout.on('data', function (data) {
       outputData += data.toString();
+    });
+  }
+
+  // show command errors
+  if (app.stderr) {
+    app.stderr.on('data', function (data) {
+      core.info(data);
     });
   }
 


### PR DESCRIPTION
Right now when the try/catch catch a dictionary, it will apply .toString() to it, printing `Error: [object Object]` to the console
This PR aims to fix that

(If you are interested, in my case the error was that git is not installed on a Ubuntu 16.04 docker image)