### PR TITLE
Fix readme to have permissions in correct place

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ name: Github Action with a cronjob trigger
 on:
   schedule:
     - cron: "0 0 * * *"
-  permissions:
-    actions: write
+permissions:
+  actions: write
 jobs:
   cronjob-based-github-action:
     name: Cronjob based github action
@@ -66,8 +66,8 @@ name: Github Action with a cronjob trigger
 on:
   schedule:
     - cron: "0 0 * * *"
-  permissions:
-    contents: write
+permissions:
+  contents: write
 jobs:
   cronjob-based-github-action:
     name: Cronjob based github action


### PR DESCRIPTION
The README for version 2 has a couple of instances of `permissions` at the wrong indent level for GitHub Actions.

This fixes it.