### PR TITLE
fix: typo in dummy commit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
       # - step n, use it as the last step
       - uses: gautamkrishnar/keepalive-workflow@v2
         with:
-          use_api: true
+          use_api: false
 
 ```
 


### PR DESCRIPTION
Corrected a small typo in the documentation for the dummy commit setup (use_api: `true` to use_api: `false`)