### PR TITLE
Support yml and yaml by matching before @

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ if (useAPI) {
   const promiseArr = []
   workflowsList.forEach((workflowFile) => {
     promiseArr.push(new Promise(async (resolve, reject) => {
-      const parentWorkflowPath = process.env.GITHUB_WORKFLOW_REF.match(/^(.*\.yml)/)[1];
+      const parentWorkflowPath = process.env.GITHUB_WORKFLOW_REF.match(/^(.*)@/)[1];
       core.info(`Executing keepalive for ${workflowFile ? workflowFile : `parent workflow (${parentWorkflowPath})`}`);
       APIKeepAliveWorkflow(githubToken, {
         autoWriteCheck,


### PR DESCRIPTION
The new `parentWorkflowPath` regex assumes `.yml` extension and errors out on `.yaml` extension, a breaking regression in version 2.0.2. I think matching before `@` is safer (`library.js` also does it that way).

```

Run gautamkrishnar/keepalive-workflow@v2
/home/runner/work/_actions/gautamkrishnar/keepalive-workflow/v2/dist/index.js:23040
      const parentWorkflowPath = process.env.GITHUB_WORKFLOW_REF.match(/^(.*\.yml)/)[1];
                                                                                    ^

TypeError: Cannot read properties of null (reading '1')
    at /home/runner/work/_actions/gautamkrishnar/keepalive-workflow/v2/dist/index.js:23040:85
    at new Promise (<anonymous>)
    at /home/runner/work/_actions/gautamkrishnar/keepalive-workflow/v2/dist/index.js:23039:21
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/home/runner/work/_actions/gautamkrishnar/keepalive-workflow/v2/dist/index.js:23038:17)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
```