### PR TITLE
replace the default elapsed time value of 50 with 45

### DIFF
--- a/library.js
+++ b/library.js
@@ -11,18 +11,18 @@ const { Octokit } = require("@octokit/rest");
  * @param {string} committerUsername - Username of the GitHub user to create dummy commit
  * @param {string} committerEmail - Email id of the GitHub user to create dummy commit
  * @param {string} commitMessage - Commit message while doing dummy commit
- * @param {number} [timeElapsed=50] - Time elapsed from the last commit to trigger a new automated commit (in days). Default: 50
+ * @param {number} [timeElapsed=45] - Time elapsed from the last commit to trigger a new automated commit (in days). Default: 45
  * @param {boolean} [autoPush=false] - Boolean flag to define if the library should automatically push the changes. Default: false
  * @param {boolean} [autoWriteCheck=false] - Enables automatic checking of the token for branch protection rules
  * @return {Promise<string, Error>} - Promise with success message or failure object
  */
-const KeepAliveWorkflow = async (githubToken, committerUsername, committerEmail, commitMessage, timeElapsed = 50, autoPush = false, autoWriteCheck = false) => {
+const KeepAliveWorkflow = async (githubToken, committerUsername, committerEmail, commitMessage, timeElapsed = 45, autoPush = false, autoWriteCheck = false) => {
   return new Promise(async (resolve, reject) => {
     try {
       writeDetectionCheck(autoWriteCheck, reject, resolve);
       const diffInDays = await getDiffInDays();
       if (diffInDays >= timeElapsed) {
-        // Do dummy commit if elapsed time is greater than 50 (default) days
+        // Do dummy commit if elapsed time is greater than 45 (default) days
         await execute('git', [
           'config',
           '--global',
@@ -68,7 +68,7 @@ const KeepAliveWorkflow = async (githubToken, committerUsername, committerEmail,
  * @property {string|null} [workflowFile=null] - Action file name to keepalive eg: `test.yaml'. If you omit this parameter,
  * the script will automatically figure it out from the current run metadata.
  * @property {string} [apiBaseUrl=process.env.GITHUB_API_URL] - API Base url. Change this if you are using GitHub enterprise hosted version.
- * @property {number} [timeElapsed=50] - Time elapsed from the last commit to trigger a new automated commit (in days). Default: 50
+ * @property {number} [timeElapsed=45] - Time elapsed from the last commit to trigger a new automated commit (in days). Default: 45
  * @property {boolean} [autoWriteCheck=false] - Enables automatic checking of the token for branch protection rules
  */
 
@@ -88,7 +88,7 @@ const APIKeepAliveWorkflow = (githubToken,
                                   (!!process.env.GITHUB_API_URL) ?
                                     process.env.GITHUB_API_URL : 'https://api.github.com'
                                 ),
-                                timeElapsed = 50,
+                                timeElapsed = 45,
                                 autoWriteCheck = false
                               } = {}) => {
   return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
# Summary

Replaced the default elpased time value of 50 with 45 to align it with `action.yml`.

# Background

I have just read through the entire code to understand how it works.

And I found that the default elapsed time value in the code is not aligned with `action.yml` default value.

The `time_elapsed` default value is defined as `45` in `action.yml`.

```diff
# action.yml

inputs:
  ...
  time_elapsed:
    description: "Time elapsed from the last commit to trigger a new automated commit or API call (in days)"
+   default: "45"
    required: false
```

But the `timeElapsed` default value is defined as `50` in `library.js`.

```diff
# library.js

const APIKeepAliveWorkflow = (githubToken,
                              {
                                workflowFile = null,
                                apiBaseUrl= (
                                  (!!process.env.GITHUB_API_URL) ?
                                    process.env.GITHUB_API_URL : 'https://api.github.com'
                                ),
+                               timeElapsed = 50,
                                autoWriteCheck = false
                              } = {}) => {
```

It confuses me as to which one is correct. 

After searching git commit logs, I can confirm that `45` is the default value. (#36)

Although it doesn't affect the running process, I think it can confuse people who read the code. 

---

Thanks for developing such a great github actions!